### PR TITLE
Update ApiClient.php

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -335,9 +335,9 @@ class ApiClient
         self::$logger->debug("HTTP Request Body:\n" . print_r($printPostData, true));
         
         // debugging for curl
-        if (($this->merchantConfig->getLogConfiguration())->isLoggingEnabled()) {
+        if ($this->merchantConfig->getLogConfiguration()->isLoggingEnabled()) {
             curl_setopt($curl, CURLOPT_VERBOSE, 1);
-            $tempBlowup = explode(DIRECTORY_SEPARATOR, ($this->merchantConfig->getLogConfiguration())->getDebugLogFile());
+            $tempBlowup = explode(DIRECTORY_SEPARATOR, $this->merchantConfig->getLogConfiguration()->getDebugLogFile());
             $normalLogFilename = end($tempBlowup);
             $filenameIndex = key($tempBlowup);
             $tempBlowup[$filenameIndex] = "curlNetwork.log";


### PR DESCRIPTION
fix extra brackets causing error in PHP5.6

> Fatal error: syntax error, unexpected '->' (T_OBJECT_OPERATOR)
> in /app/vendor/cybersource/rest-client-php/lib/ApiClient.php on line 338

I'm still testing this... will update once i have had a play